### PR TITLE
feat: add live in-game scoreboard dashboard

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -435,6 +435,104 @@ header p {
   color: var(--yellow);
 }
 
+/* ── Live In-Game Dashboard ── */
+.live-dashboard {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 160px;
+  max-height: 40%;
+  overflow-y: auto;
+  background: rgba(15,14,23,0.75);
+  backdrop-filter: blur(4px);
+  border: 1px solid #2a2a4a;
+  border-radius: 6px;
+  padding: 6px;
+  pointer-events: none;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-family: 'Press Start 2P', monospace;
+}
+.live-dashboard.hidden { display: none; }
+
+.live-dash-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 4px;
+  border-radius: 3px;
+  background: rgba(255,255,255,0.03);
+  transition: transform 0.3s ease;
+  position: relative;
+}
+.live-dash-row.is-me {
+  border-left: 2px solid var(--teal);
+  background: rgba(78,205,196,0.08);
+}
+
+.live-dash-rank {
+  font-size: 5px;
+  color: var(--muted);
+  width: 10px;
+  text-align: center;
+  flex-shrink: 0;
+}
+.live-dash-row:first-child .live-dash-rank {
+  color: var(--yellow);
+}
+
+.live-dash-name {
+  font-size: 5px;
+  color: var(--muted);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+.live-dash-icon {
+  font-size: 10px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.live-dash-score {
+  font-size: 5px;
+  color: var(--yellow);
+  flex-shrink: 0;
+  position: relative;
+}
+.live-dash-score.score-pop {
+  animation: live-score-pop 0.3s ease-out;
+}
+
+.live-dash-delta {
+  position: absolute;
+  right: 0;
+  top: -8px;
+  font-size: 5px;
+  color: var(--teal);
+  pointer-events: none;
+  white-space: nowrap;
+  animation: live-delta-rise 0.8s ease-out forwards;
+}
+
+@keyframes live-score-pop {
+  0% { transform: scale(1); }
+  40% { transform: scale(1.5); color: var(--teal); }
+  100% { transform: scale(1); }
+}
+
+@keyframes live-delta-rise {
+  0% { transform: translateY(0); opacity: 1; }
+  100% { transform: translateY(-12px); opacity: 0; }
+}
+
 /* ── Name entry screen ── */
 .name-entry {
   position: fixed;

--- a/public/index.html
+++ b/public/index.html
@@ -219,6 +219,7 @@
         <div class="screen-sub">MEGA BUG incoming!</div>
       </div>
 
+      <div class="live-dashboard hidden" id="live-dashboard"></div>
     </div>
   </div>
 

--- a/public/js/network.js
+++ b/public/js/network.js
@@ -1,7 +1,7 @@
 import { LOGICAL_W, LOGICAL_H } from './config.js';
 import { dom, clientState } from './state.js';
 import { logicalToPixel } from './coordinates.js';
-import { updateHUD, updatePlayerCount, hideAllScreens, showStartScreen, showGameOverScreen, showWinScreen, showLevelScreen, updateLobbyRoster } from './hud.js';
+import { updateHUD, updatePlayerCount, hideAllScreens, showStartScreen, showGameOverScreen, showWinScreen, showLevelScreen, updateLobbyRoster, updateLiveDashboard, showLiveDashboard, hideLiveDashboard } from './hud.js';
 import { createBugElement, removeBugElement, clearAllBugs, showSquashEffect, removeMergeTether, removePipelineTether, rebuildPipelineTether } from './bugs.js';
 import { createBossElement, updateBossHp, removeBossElement, showBossHitEffect, formatTime } from './boss.js';
 import { addRemoteCursor, removeRemoteCursor, updateRemoteCursor, clearRemoteCursors } from './players.js';
@@ -180,10 +180,10 @@ function handleMessage(msg) {
       if (msg.phase === 'boss') dom.levelEl.textContent = 'BOSS';
       clientState.currentPhase = msg.phase;
 
-      if (msg.phase === 'lobby') showStartScreen();
-      else if (msg.phase === 'gameover') showGameOverScreen(msg.score, msg.level, msg.players || []);
-      else if (msg.phase === 'win') showWinScreen(msg.score, msg.players || []);
-      else hideAllScreens();
+      if (msg.phase === 'lobby') { showStartScreen(); hideLiveDashboard(); }
+      else if (msg.phase === 'gameover') { showGameOverScreen(msg.score, msg.level, msg.players || []); hideLiveDashboard(); }
+      else if (msg.phase === 'win') { showWinScreen(msg.score, msg.players || []); hideLiveDashboard(); }
+      else { hideAllScreens(); showLiveDashboard(); }
       break;
     }
 
@@ -197,6 +197,7 @@ function handleMessage(msg) {
       removeDuckBuffOverlay();
       clearRemoteCursors();
       hideAllScreens();
+      hideLiveDashboard();
       updateHUD(0, 1, 100);
       updatePlayerCount();
       document.getElementById('hud-leave-btn').classList.add('hidden');
@@ -217,6 +218,7 @@ function handleMessage(msg) {
       if (p.id !== clientState.myId) addRemoteCursor(p.id, p.name, p.color, p.icon);
       updatePlayerCount();
       updateLobbyRoster();
+      updateLiveDashboard();
       break;
     }
 
@@ -225,6 +227,7 @@ function handleMessage(msg) {
       removeRemoteCursor(msg.playerId);
       updatePlayerCount();
       updateLobbyRoster();
+      updateLiveDashboard();
       break;
     }
 
@@ -246,12 +249,14 @@ function handleMessage(msg) {
       if (msg.players) {
         msg.players.forEach(p => { if (clientState.players[p.id]) clientState.players[p.id].score = p.score; });
       }
+      showLiveDashboard();
       break;
     }
 
     case 'level-start': {
       hideAllScreens();
       updateHUD(msg.score, msg.level, msg.hp);
+      showLiveDashboard();
       break;
     }
 
@@ -309,6 +314,7 @@ function handleMessage(msg) {
       if (clientState.players[msg.playerId]) {
         clientState.players[msg.playerId].score = msg.playerScore;
       }
+      updateLiveDashboard();
       break;
     }
 
@@ -401,6 +407,7 @@ function handleMessage(msg) {
       if (clientState.players[msg.playerId]) {
         clientState.players[msg.playerId].score = msg.playerScore;
       }
+      updateLiveDashboard();
       showDuckBuffOverlay(msg.buffDuration);
       break;
     }
@@ -427,6 +434,7 @@ function handleMessage(msg) {
       if (clientState.players[msg.playerId]) {
         clientState.players[msg.playerId].score = msg.playerScore;
       }
+      updateLiveDashboard();
       showHammerShockwave(msg.playerColor);
       break;
     }
@@ -477,6 +485,7 @@ function handleMessage(msg) {
           if (clientState.players[pid]) clientState.players[pid].score = score;
         }
       }
+      updateLiveDashboard();
       break;
     }
 
@@ -526,6 +535,7 @@ function handleMessage(msg) {
       if (clientState.players[msg.playerId]) {
         clientState.players[msg.playerId].score = msg.playerScore;
       }
+      updateLiveDashboard();
       break;
     }
 
@@ -538,6 +548,7 @@ function handleMessage(msg) {
       if (clientState.players[msg.playerId]) {
         clientState.players[msg.playerId].score = msg.playerScore;
       }
+      updateLiveDashboard();
       break;
     }
 
@@ -578,6 +589,7 @@ function handleMessage(msg) {
       removeBossElement();
       removeDuckElement();
       removeDuckBuffOverlay();
+      hideLiveDashboard();
       shakeArena('heavy');
       showGameOverScreen(msg.score, msg.level, msg.players || []);
       break;
@@ -585,6 +597,7 @@ function handleMessage(msg) {
 
     case 'game-win': {
       clearAllBugs();
+      hideLiveDashboard();
       showWinScreen(msg.score, msg.players || []);
       break;
     }
@@ -594,6 +607,7 @@ function handleMessage(msg) {
       dom.levelEl.textContent = 'BOSS';
       createBossElement(msg.boss.x, msg.boss.y, msg.boss.hp, msg.boss.maxHp, msg.boss.enraged, msg.timeRemaining);
       updateHUD(msg.score, undefined, msg.hp);
+      showLiveDashboard();
       break;
     }
 
@@ -621,6 +635,7 @@ function handleMessage(msg) {
         clientState.players[msg.playerId].score = msg.playerScore;
       }
       clientState.bossEnraged = msg.enraged;
+      updateLiveDashboard();
       break;
     }
 
@@ -655,6 +670,7 @@ function handleMessage(msg) {
         msg.players.forEach(p => { if (clientState.players[p.id]) clientState.players[p.id].score = p.score; });
       }
       updateHUD(msg.score);
+      updateLiveDashboard();
       break;
     }
 
@@ -663,6 +679,7 @@ function handleMessage(msg) {
       removeBossElement();
       removeDuckElement();
       removeDuckBuffOverlay();
+      hideLiveDashboard();
       showStartScreen();
       updateHUD(0, 1, 100);
       break;

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -68,6 +68,7 @@ export const dom = {
   leaderboardList: null,
   leaderboardTab: null,
   lobbiesTab: null,
+  liveDashboard: null,
 };
 
 export function initDom() {
@@ -115,4 +116,5 @@ export function initDom() {
   dom.leaderboardList = document.getElementById('leaderboard-list');
   dom.leaderboardTab = document.getElementById('leaderboard-tab');
   dom.lobbiesTab = document.getElementById('lobbies-tab');
+  dom.liveDashboard = document.getElementById('live-dashboard');
 }


### PR DESCRIPTION
## Summary
- Adds a compact, semi-transparent scoreboard panel in the arena top-right corner during active gameplay (playing and boss phases)
- Scores update in real-time with pop animations and floating "+N" delta indicators when players earn points
- Rank reordering uses FLIP animation for smooth transitions when a player overtakes another

## Test plan
- [ ] Start a game with 2+ players and verify the dashboard appears in the top-right during gameplay
- [ ] Squash bugs and verify scores update with pop animation and floating delta
- [ ] Verify rank reordering animates smoothly when a lower player overtakes a higher one
- [ ] Verify current player row has a teal left-border highlight
- [ ] Verify clicking bugs underneath the dashboard still works (pointer-events passthrough)
- [ ] Verify dashboard hides on game-over/win screens and reappears on retry
- [ ] Test with a single player to verify it still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)